### PR TITLE
Migrate QR manager to web interface with tools menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+qr_data.json
+*.png
+*.svg
+qr_manager.log
+qr_manager.service

--- a/README.md
+++ b/README.md
@@ -1,2 +1,83 @@
-# QR
-gestion de QR
+# Gestor de Códigos QR Web
+
+Aplicación web para crear, editar y administrar códigos QR dentro de una organización. Todo se maneja desde el navegador y está protegido por inicio de sesión.
+
+## Características
+- Inicio de sesión obligatorio (usuario `Admin`, contraseña `BTR6969`).
+- Dos tipos de códigos: **normal** (URL o texto) y **WiFi** (SSID y contraseña).
+- Personalización de colores, texto opcional y formatos **PNG** o **SVG**.
+- Menú **Herramientas** para ver el registro, instalar la aplicación como servicio `systemd` y consultar su estado.
+- Los códigos y sus datos se guardan en `qr_data.json` y las imágenes en `static/qrs/`.
+
+## Requisitos previos
+- Ordenador con Ubuntu o Debian y acceso a Internet.
+- Terminal con permisos de administrador (`sudo`).
+- [Git](https://git-scm.com/), [Python 3](https://www.python.org/) y `pip`.
+
+## Instalación paso a paso
+1. **Instalar Git**
+   ```bash
+   sudo apt update
+   sudo apt install git
+   ```
+2. **Clonar este repositorio**
+   ```bash
+   git clone https://github.com/USER/QR.git
+   cd QR
+   ```
+   Para actualizar más tarde utiliza:
+   ```bash
+   git pull
+   ```
+3. **Instalar Python y pip (si no están)**
+   ```bash
+   sudo apt install python3 python3-pip
+   ```
+4. **Instalar dependencias del proyecto**
+   ```bash
+   pip install -r requirements.txt
+   ```
+   Si recibes un error de permisos añade `--user` o ejecuta el comando con `sudo`.
+
+## Uso de la aplicación
+1. Ejecuta el servidor:
+   ```bash
+   python3 qr_manager.py
+   ```
+2. Abre el navegador en `http://localhost:5000`.
+3. Introduce las credenciales solicitadas:
+   - Usuario: `Admin`
+   - Contraseña: `BTR6969`
+4. Desde el panel principal puedes:
+   - Crear un nuevo código QR (normal o WiFi).
+   - Editar o eliminar códigos existentes.
+   - Acceder al menú **Herramientas**.
+5. En **Herramientas** puedes:
+   - Ver el contenido del archivo de log `qr_manager.log`.
+   - Instalar la aplicación como servicio `systemd` (requiere `sudo`).
+   - Consultar el estado del servicio `qr_manager`.
+
+## Archivos generados
+- `qr_data.json`: base de datos con la información de los códigos creados.
+- `static/qrs/`: carpeta con las imágenes PNG o SVG generadas.
+- `qr_manager.log`: registro de eventos de la aplicación.
+
+## Actualizar el programa
+Cuando haya una nueva versión, navega al directorio del proyecto y ejecuta:
+```bash
+git pull
+```
+
+## Problemas comunes
+- **Faltan dependencias**: asegúrate de haber ejecutado `pip install -r requirements.txt`.
+- **Permiso denegado al instalar el servicio**: ejecuta la acción con `sudo`.
+- **No puedo acceder a la web**: verifica que el servidor esté en ejecución y que no haya un firewall bloqueando el puerto 5000.
+
+## Desinstalar el servicio (opcional)
+Si ya no deseas que se ejecute al inicio:
+```bash
+sudo systemctl disable qr_manager.service
+sudo rm /etc/systemd/system/qr_manager.service
+```
+
+¡Listo! Con estos pasos cualquier persona, incluso sin experiencia previa, puede gestionar sus códigos QR desde una interfaz web.

--- a/qr_manager.py
+++ b/qr_manager.py
@@ -1,0 +1,229 @@
+import json
+import os
+import subprocess
+import logging
+from functools import wraps
+from typing import Dict, Any
+
+from flask import Flask, render_template, request, redirect, url_for, session, flash
+import qrcode
+from qrcode.image.svg import SvgImage
+from PIL import Image, ImageDraw, ImageFont
+
+DATA_FILE = "qr_data.json"
+LOG_FILE = "qr_manager.log"
+QR_DIR = os.path.join("static", "qrs")
+os.makedirs(QR_DIR, exist_ok=True)
+
+logging.basicConfig(filename=LOG_FILE, level=logging.INFO, format="%(asctime)s %(message)s")
+
+app = Flask(__name__)
+app.secret_key = "super-secret"  # cambie esta clave en producción
+
+
+def load_data() -> Dict[str, Any]:
+    if os.path.exists(DATA_FILE):
+        with open(DATA_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_data(data: Dict[str, Any]) -> None:
+    with open(DATA_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=4, ensure_ascii=False)
+
+
+def generate_qr(name: str, info: Dict[str, Any]) -> str:
+    if info["type"] == "url":
+        qr_data = info.get("url", "")
+    else:
+        qr_data = f"WIFI:T:{info.get('encryption','WPA')};S:{info.get('ssid','')};P:{info.get('password','')};;"
+    qr = qrcode.QRCode(error_correction=qrcode.constants.ERROR_CORRECT_H)
+    qr.add_data(qr_data)
+    qr.make(fit=True)
+    fmt = info.get("format", "png").lower()
+    color = info.get("color", "black")
+    background = info.get("background", "white")
+    filename = f"{name}.{fmt if fmt == 'svg' else 'png'}"
+    filepath = os.path.join(QR_DIR, filename)
+    if fmt == "svg":
+        img = qr.make_image(image_factory=SvgImage, fill_color=color, back_color=background)
+        img.save(filepath)
+    else:
+        img = qr.make_image(fill_color=color, back_color=background)
+        img.save(filepath)
+        text = info.get("text")
+        if text:
+            try:
+                img_with_text = Image.open(filepath)
+                draw = ImageDraw.Draw(img_with_text)
+                font = ImageFont.load_default()
+                w, h = img_with_text.size
+                draw.text((10, h - 10), text, fill=color, font=font, anchor="ld")
+                img_with_text.save(filepath)
+            except Exception:
+                pass
+    logging.info("Generado %s", filename)
+    return filename
+
+
+def install_service() -> None:
+    script = os.path.abspath(__file__)
+    python = os.environ.get("PYTHON", "python3")
+    service = f"""[Unit]
+Description=QR Manager Web
+After=network.target
+
+[Service]
+ExecStart={python} {script}
+Restart=always
+User={os.environ.get('USER', 'root')}
+
+[Install]
+WantedBy=multi-user.target
+"""
+    service_path = "/etc/systemd/system/qr_manager.service"
+    tmp_file = "qr_manager.service"
+    with open(tmp_file, "w", encoding="utf-8") as f:
+        f.write(service)
+    try:
+        subprocess.run(["sudo", "cp", tmp_file, service_path], check=True)
+        subprocess.run(["sudo", "systemctl", "daemon-reload"], check=True)
+        subprocess.run(["sudo", "systemctl", "enable", "--now", "qr_manager"], check=True)
+        logging.info("Servicio instalado")
+    except Exception as e:  # pragma: no cover - depende del sistema
+        logging.error("No se pudo instalar el servicio: %s", e)
+
+
+def login_required(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        if "user" not in session:
+            return redirect(url_for("login"))
+        return f(*args, **kwargs)
+    return wrapper
+
+
+@app.route("/", methods=["GET", "POST"])
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    if "user" in session:
+        return redirect(url_for("dashboard"))
+    if request.method == "POST":
+        if request.form.get("username") == "Admin" and request.form.get("password") == "BTR6969":
+            session["user"] = "Admin"
+            return redirect(url_for("dashboard"))
+        flash("Credenciales incorrectas")
+    return render_template("login.html")
+
+
+@app.route("/logout")
+def logout():
+    session.clear()
+    return redirect(url_for("login"))
+
+
+@app.route("/dashboard")
+@login_required
+def dashboard():
+    data = load_data()
+    return render_template("dashboard.html", data=data)
+
+
+@app.route("/create", methods=["GET", "POST"])
+@login_required
+def create_qr():
+    if request.method == "POST":
+        name = request.form.get("name")
+        info = {
+            "type": request.form.get("type", "url"),
+            "url": request.form.get("data"),
+            "ssid": request.form.get("data"),
+            "password": request.form.get("password"),
+            "text": request.form.get("text"),
+            "color": request.form.get("color"),
+            "background": request.form.get("background"),
+            "format": request.form.get("format", "png"),
+        }
+        generate_qr(name, info)
+        data = load_data()
+        data[name] = info
+        save_data(data)
+        flash("QR guardado")
+        return redirect(url_for("dashboard"))
+    info = {"type": "url"}
+    return render_template("form.html", name="", info=info)
+
+
+@app.route("/edit/<name>", methods=["GET", "POST"])
+@login_required
+def edit_qr(name):
+    data = load_data()
+    info = data.get(name)
+    if not info:
+        flash("QR no encontrado")
+        return redirect(url_for("dashboard"))
+    if request.method == "POST":
+        info.update({
+            "type": request.form.get("type", "url"),
+            "url": request.form.get("data"),
+            "ssid": request.form.get("data"),
+            "password": request.form.get("password"),
+            "text": request.form.get("text"),
+            "color": request.form.get("color"),
+            "background": request.form.get("background"),
+            "format": request.form.get("format", "png"),
+        })
+        generate_qr(name, info)
+        save_data(data)
+        flash("QR actualizado")
+        return redirect(url_for("dashboard"))
+    return render_template("form.html", name=name, info=info)
+
+
+@app.route("/delete/<name>")
+@login_required
+def delete_qr(name):
+    data = load_data()
+    info = data.pop(name, None)
+    if info:
+        save_data(data)
+        fname = f"{name}.{info.get('format', 'png')}" if info.get('format') == 'svg' else f"{name}.png"
+        try:
+            os.remove(os.path.join(QR_DIR, fname))
+        except FileNotFoundError:
+            pass
+        flash("QR eliminado")
+    return redirect(url_for("dashboard"))
+
+
+@app.route("/tools")
+@login_required
+def tools():
+    log_content = ""
+    if os.path.exists(LOG_FILE):
+        with open(LOG_FILE, "r", encoding="utf-8") as f:
+            log_content = f.read()
+    return render_template("tools.html", log=log_content)
+
+
+@app.route("/tools/install", methods=["POST"])
+@login_required
+def install_service_route():
+    install_service()
+    flash("Solicitud de instalación enviada")
+    return redirect(url_for("tools"))
+
+
+@app.route("/tools/status")
+@login_required
+def service_status():
+    try:
+        output = subprocess.check_output(["systemctl", "status", "qr_manager"], text=True)
+    except Exception as e:  # pragma: no cover - depende del sistema
+        output = str(e)
+    return render_template("status.html", status=output)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+qrcode
+Pillow
+Flask

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Gestor QR</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('dashboard') }}">QR Manager</a>
+    <div class="collapse navbar-collapse">
+      <ul class="navbar-nav me-auto">
+        {% if session.get('user') %}
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard') }}">Inicio</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('tools') }}">Herramientas</a></li>
+        {% endif %}
+      </ul>
+      {% if session.get('user') %}
+        <span class="navbar-text me-3">{{ session['user'] }}</span>
+        <a class="btn btn-outline-light" href="{{ url_for('logout') }}">Salir</a>
+      {% endif %}
+    </div>
+  </div>
+</nav>
+<div class="container">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <div class="alert alert-info">
+      {% for m in messages %}{{ m }}<br>{% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
+  {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Códigos QR</h2>
+<a class="btn btn-success mb-3" href="{{ url_for('create_qr') }}">Crear nuevo</a>
+<table class="table table-striped">
+  <tr><th>Nombre</th><th>Tipo</th><th>Acciones</th></tr>
+  {% for name, info in data.items() %}
+  <tr>
+    <td>{{ name }}</td>
+    <td>{{ info['type'] }}</td>
+    <td>
+      <a class="btn btn-sm btn-primary" href="{{ url_for('edit_qr', name=name) }}">Editar</a>
+      <a class="btn btn-sm btn-danger" href="{{ url_for('delete_qr', name=name) }}" onclick="return confirm('¿Eliminar?')">Eliminar</a>
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>{{ 'Editar' if name else 'Crear' }} QR</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Nombre</label>
+    <input class="form-control" name="name" value="{{ name }}" {% if name %}readonly{% endif %}>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Tipo</label>
+    <select class="form-select" name="type" id="type-select">
+      <option value="url" {% if info['type']=='url' %}selected{% endif %}>Normal</option>
+      <option value="wifi" {% if info['type']=='wifi' %}selected{% endif %}>WiFi</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Dato / URL o SSID</label>
+    <input class="form-control" name="data" value="{{ info.get('url', info.get('ssid', '')) }}">
+  </div>
+  <div class="mb-3" id="password-field" {% if info['type']!='wifi' %}style="display:none"{% endif %}>
+    <label class="form-label">Contraseña WiFi</label>
+    <input class="form-control" name="password" value="{{ info.get('password','') }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Texto opcional</label>
+    <input class="form-control" name="text" value="{{ info.get('text','') }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Color</label>
+    <input class="form-control" name="color" value="{{ info.get('color','black') }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Fondo</label>
+    <input class="form-control" name="background" value="{{ info.get('background','white') }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Formato</label>
+    <select class="form-select" name="format">
+      <option value="png" {% if info.get('format','png')=='png' %}selected{% endif %}>PNG</option>
+      <option value="svg" {% if info.get('format')=='svg' %}selected{% endif %}>SVG</option>
+    </select>
+  </div>
+  <button class="btn btn-primary" type="submit">Guardar</button>
+</form>
+<script>
+const select = document.getElementById('type-select');
+select.addEventListener('change', function(){
+  document.getElementById('password-field').style.display = this.value==='wifi' ? 'block' : 'none';
+});
+</script>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-4">
+    <h2 class="mb-3">Iniciar sesión</h2>
+    <form method="post">
+      <div class="mb-3">
+        <label class="form-label">Usuario</label>
+        <input class="form-control" name="username">
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Contraseña</label>
+        <input type="password" class="form-control" name="password">
+      </div>
+      <button class="btn btn-primary" type="submit">Entrar</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Estado del servicio</h2>
+<pre class="bg-light p-3 border" style="max-height:400px;overflow:auto;">{{ status }}</pre>
+{% endblock %}

--- a/templates/tools.html
+++ b/templates/tools.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Herramientas</h2>
+<form method="post" action="{{ url_for('install_service_route') }}">
+  <button class="btn btn-warning">Instalar como servicio</button>
+</form>
+<a class="btn btn-info mt-3" href="{{ url_for('service_status') }}">Ver estado del servicio</a>
+<h3 class="mt-4">Registro</h3>
+<pre class="bg-light p-3 border" style="max-height:300px;overflow:auto;">{{ log }}</pre>
+{% endblock %}


### PR DESCRIPTION
## Summary
- replace console/Tkinter app with Flask web interface requiring Admin/BTR6969 login
- manage URL or WiFi QR codes with color, text and PNG/SVG options
- add Herramientas page to view logs, install as systemd service and check service status
- update README with beginner-friendly setup and web usage instructions

## Testing
- `python -m py_compile qr_manager.py`
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement qrcode)*

------
https://chatgpt.com/codex/tasks/task_e_689b0a74a25883269729d0858fcef167